### PR TITLE
Update upstream IPs and add PUBG redirect route

### DIFF
--- a/hosts/brim/caddy-routes.nix
+++ b/hosts/brim/caddy-routes.nix
@@ -22,6 +22,21 @@
         ];
       }
       {
+        match = [ { host = [ "pubg.brim.su" ]; } ];
+        terminal = true;
+        handle = [
+          {
+            # The upstream is plain HTTP only; proxying it under forced TLS
+            # breaks the page (mixed content), so send the browser there
+            # directly. 302 keeps the redirect re-resolvable when the
+            # upstream address changes.
+            handler = "static_response";
+            status_code = 302; # Found
+            headers.Location = [ "http://195.170.194.163:7290/" ];
+          }
+        ];
+      }
+      {
         match = [ { host = [ "ip.brim.su" ]; } ];
         terminal = true;
         handle = [

--- a/hosts/brim/caddy-routes.nix
+++ b/hosts/brim/caddy-routes.nix
@@ -7,7 +7,7 @@
         handle = [
           {
             handler = "reverse_proxy";
-            upstreams = [ { dial = "62.217.184.232:1896"; } ];
+            upstreams = [ { dial = "195.170.194.163:1896"; } ];
           }
         ];
       }
@@ -17,7 +17,7 @@
         handle = [
           {
             handler = "reverse_proxy";
-            upstreams = [ { dial = "62.217.184.232:2017"; } ];
+            upstreams = [ { dial = "195.170.194.163:2017"; } ];
           }
         ];
       }


### PR DESCRIPTION
## Summary
Updates upstream server addresses for existing Caddy routes and adds a new redirect route for the PUBG service.

## Changes
- Updated upstream IP address from `62.217.184.232` to `195.170.194.163` for both existing routes (ports 1896 and 2017)
- Added new route for `pubg.brim.su` that performs a 302 redirect to the upstream HTTP service at `http://195.170.194.163:7290/`

## Implementation Details
The PUBG route uses a static response handler with a 302 (Found) status code rather than reverse proxying. This is necessary because the upstream service only supports plain HTTP, and proxying it under forced TLS would cause mixed content issues. The 302 status code allows the redirect to be re-resolved when the upstream address changes in the future.

https://claude.ai/code/session_0155BSSjVix5U1JRQWEX8VNB