### PR TITLE
feat(brim): serve pubg.brim.su through a reverse proxy

### DIFF
--- a/hosts/brim/caddy-routes.nix
+++ b/hosts/brim/caddy-routes.nix
@@ -26,13 +26,8 @@
         terminal = true;
         handle = [
           {
-            # The upstream is plain HTTP only; proxying it under forced TLS
-            # breaks the page (mixed content), so send the browser there
-            # directly. 302 keeps the redirect re-resolvable when the
-            # upstream address changes.
-            handler = "static_response";
-            status_code = 302; # Found
-            headers.Location = [ "http://195.170.194.163:7290/" ];
+            handler = "reverse_proxy";
+            upstreams = [ { dial = "195.170.194.163:7290"; } ];
           }
         ];
       }


### PR DESCRIPTION
The radar upstream now works behind TLS, so proxy it like the other external services instead of redirecting the browser to plain HTTP.


Claude-Session: https://claude.ai/code/session_0155BSSjVix5U1JRQWEX8VNB